### PR TITLE
Fix daily export null handling and add fetcher tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # production
 /build
+dist-test/
 
 # debug
 npm-debug.log*

--- a/app/admin/students/page.tsx
+++ b/app/admin/students/page.tsx
@@ -327,7 +327,7 @@ export default function StudentManagement() {
               <div className="px-6 py-4 border-b border-gray-200">
                 <h3 className="text-lg font-medium text-gray-900">CSV Upload</h3>
                 <p className="text-sm text-gray-600 mt-1">
-                  Format: Lastname, Firstname, class, subclass (one per line)
+                  Format: Last name, First name, class, subclass (one per line)
                   <br />
                   Example: Sturn, Ava, K, B (creates class "KB")
                   <br />

--- a/app/api/admin/download-daily/route.ts
+++ b/app/api/admin/download-daily/route.ts
@@ -38,9 +38,11 @@ export async function GET() {
     // Convert to CSV format
     const csvHeaders = ["Student Name", "Class", "Signed Out By", "Sign-Out Time"]
 
-    const csvRows = records.map((record: any) => [
-      `${record.students.first_name} ${record.students.last_name}`,
-      record.students.classes.name,
+    const safeRecords = records ?? []
+
+    const csvRows = safeRecords.map((record: any) => [
+      `${record.students?.first_name ?? ""} ${record.students?.last_name ?? ""}`.trim(),
+      record.students?.classes?.name ?? "",
       record.signer_name,
       new Date(record.signed_out_at).toLocaleString(),
     ])

--- a/lib/__tests__/fetcher.test.ts
+++ b/lib/__tests__/fetcher.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import { jsonFetch } from '../fetcher'
+
+const originalFetch = global.fetch
+
+describe('jsonFetch', () => {
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it('adds a cache-busting timestamp and disables caching by default', async () => {
+    const calls: Array<[unknown, RequestInit | undefined]> = []
+
+    global.fetch = (async (input: unknown, init?: RequestInit) => {
+      calls.push([input, init])
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      } as any
+    }) as typeof fetch
+
+    const result = await jsonFetch<{ success: boolean }>('/api/test')
+
+    assert.deepEqual(result, { success: true })
+    assert.ok(calls.length === 1, 'fetch should be called exactly once')
+
+    const [url, options] = calls[0]
+    assert.match(String(url), /^\/api\/test\?ts=\d+$/)
+    assert.equal(options?.cache, 'no-store')
+    const headers = options?.headers as any
+    const acceptHeader = headers?.['Accept'] ?? headers?.get?.('Accept')
+    assert.equal(acceptHeader, 'application/json')
+  })
+
+  it('respects opt-out flags and merges custom headers', async () => {
+    const calls: Array<[unknown, RequestInit | undefined]> = []
+
+    global.fetch = (async (input: unknown, init?: RequestInit) => {
+      calls.push([input, init])
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ payload: 'ok' }),
+      } as any
+    }) as typeof fetch
+
+    const result = await jsonFetch<{ payload: string }>('/api/test?foo=bar', {
+      bustCache: false,
+      noStore: false,
+      cache: 'force-cache',
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    })
+
+    assert.deepEqual(result, { payload: 'ok' })
+    assert.ok(calls.length === 1)
+
+    const [url, options] = calls[0]
+    assert.equal(url, '/api/test?foo=bar')
+    assert.equal(options?.cache, 'force-cache')
+    const headers = options?.headers as any
+    const acceptHeader = headers?.['Accept'] ?? headers?.get?.('Accept')
+    const authHeader = headers?.['Authorization'] ?? headers?.get?.('Authorization')
+    assert.equal(acceptHeader, 'application/json')
+    assert.equal(authHeader, 'Bearer token')
+  })
+
+  it('surfaces API error messages', async () => {
+    global.fetch = (async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'Boom' }),
+    })) as unknown as typeof fetch
+
+    await assert.rejects(() => jsonFetch('/api/error'), /Boom/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "test": "rm -rf dist-test && tsc -p tsconfig.test.json && node --test \"dist-test/**/*.test.js\"",
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start"

--- a/scripts/002_remove_signin_functionality.sql
+++ b/scripts/002_remove_signin_functionality.sql
@@ -1,8 +1,8 @@
--- Remove sign-in functionality by making signed_back_in_at column obsolete
--- We'll keep the column for historical data but it won't be used going forward
+-- Retire the sign-in flow from the kiosk UI while keeping signed_back_in_at available
+-- The column continues to power admin history and reporting, so preserve the data
 
 -- Update any existing records to remove sign-in timestamps (optional - for clean slate)
 -- UPDATE sign_out_records SET signed_back_in_at = NULL;
 
--- Add a comment to document the change
-COMMENT ON COLUMN sign_out_records.signed_back_in_at IS 'DEPRECATED: Sign-in functionality removed. Column kept for historical data only.';
+-- Add a comment to document the change and remaining usage
+COMMENT ON COLUMN sign_out_records.signed_back_in_at IS 'Sign-in flow removed from kiosk; column retained for admin sign-back-in tracking and historical data.';

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist-test",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "types": ["node"]
+  },
+  "include": [
+    "lib/fetcher.ts",
+    "lib/__tests__/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- correct the CSV upload helper text to use "Last name" in the admin student manager
- guard the daily export API against null result sets and document ongoing use of the sign-back-in column
- add a lightweight node:test harness and unit tests that cover jsonFetch cache busting and error propagation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cccda498d08323aaaf7c426a490876